### PR TITLE
Add endpoint to check auto, potential,conflict matches

### DIFF
--- a/server/lib/esMatching.js
+++ b/server/lib/esMatching.js
@@ -189,6 +189,7 @@ const buildQuery = (sourceResource, decisionRule) => {
 const getESDocument = (query, callback) => {
   let error = false;
   let documents = [];
+  let callbackCalled = false; // Flag to track if callback has been called
   if(!query) {
     query = {};
   }
@@ -226,6 +227,7 @@ const getESDocument = (query, callback) => {
             scroll_id: scroll_id
           };
         }
+        callbackCalled = true; // Set the flag after calling the callback
         return callback(null);
       }).catch((err) => {
         if(err.response && err.response.status === 429) {
@@ -238,7 +240,10 @@ const getESDocument = (query, callback) => {
           error = err;
           logger.error(err);
           scroll_id = null;
-          return callback(null);
+          if (!callbackCalled) {
+            callbackCalled = true;
+            return callback(null);
+          }
         }
       });
     },

--- a/server/lib/esMatching.js
+++ b/server/lib/esMatching.js
@@ -189,7 +189,6 @@ const buildQuery = (sourceResource, decisionRule) => {
 const getESDocument = (query, callback) => {
   let error = false;
   let documents = [];
-  let callbackCalled = false; // Flag to track if callback has been called
   if(!query) {
     query = {};
   }
@@ -227,7 +226,6 @@ const getESDocument = (query, callback) => {
             scroll_id: scroll_id
           };
         }
-        callbackCalled = true; // Set the flag after calling the callback
         return callback(null);
       }).catch((err) => {
         if(err.response && err.response.status === 429) {
@@ -240,10 +238,7 @@ const getESDocument = (query, callback) => {
           error = err;
           logger.error(err);
           scroll_id = null;
-          if (!callbackCalled) {
-            callbackCalled = true;
-            return callback(null);
-          }
+          return callback(null);
         }
       });
     },

--- a/server/lib/routes/match.js
+++ b/server/lib/routes/match.js
@@ -1081,7 +1081,7 @@ router.get(`/count-new-auto-matches`, (req, res) => {
   });
 });
 
-router.post('/general-matches', (req, res) => {
+router.post('/matches', (req, res) => {
   logger.info("Received a request to get all matches");
   let matchResults = {
     parent: [],

--- a/server/lib/routes/match.js
+++ b/server/lib/routes/match.js
@@ -1080,8 +1080,9 @@ router.get(`/count-new-auto-matches`, (req, res) => {
     return res.status(200).json({total: autoCount.total});
   });
 });
-router.post('/potential-matches', (req, res) => {
-  logger.info("Received a request to get potential matches");
+
+router.post('/general-matches', (req, res) => {
+  logger.info("Received a request to get all matches");
   let matchResults = {
     parent: [],
     auto: [],

--- a/server/lib/routes/match.js
+++ b/server/lib/routes/match.js
@@ -1162,7 +1162,7 @@ router.post('/matches', (req, res) => {
       let phone = '';
       if(patient.telecom) {
         for(let telecom of patient.telecom) {
-          if(telecom.system === 'phone') {
+          if(telecom.system === 'phone' && telecom.value !== '' && telecom.value !== undefined) {
               if (phone) { 
                 phone += ', ';
               }
@@ -1365,7 +1365,7 @@ router.get('/potential-matches/:id', (req, res) => {
       let phone = '';
       if(patient.telecom) {
         for(let telecom of patient.telecom) {
-          if(telecom.system === 'phone') {
+          if(telecom.system === 'phone' && telecom.value !== '' && telecom.value !== undefined) {
             if (phone) { 
               phone += ', ';
             }

--- a/server/lib/routes/match.js
+++ b/server/lib/routes/match.js
@@ -1159,11 +1159,14 @@ router.post('/matches', (req, res) => {
         }
       }
       let systemName = generalMixin.getClientDisplayName(clientUserId);
-      let phone;
+      let phone = '';
       if(patient.telecom) {
         for(let telecom of patient.telecom) {
           if(telecom.system === 'phone') {
-            phone = telecom.value;
+              if (phone) { 
+                phone += ', ';
+              }
+              phone += telecom.value;
           }
         }
       }
@@ -1359,11 +1362,14 @@ router.get('/potential-matches/:id', (req, res) => {
         }
       }
       let systemName = generalMixin.getClientDisplayName(clientUserId);
-      let phone;
+      let phone = '';
       if(patient.telecom) {
         for(let telecom of patient.telecom) {
           if(telecom.system === 'phone') {
-            phone = telecom.value;
+            if (phone) { 
+              phone += ', ';
+            }
+            phone += telecom.value;
           }
         }
       }


### PR DESCRIPTION
Add an endpoint to get potential, auto and conflict matches without creating the patient first.
This post request expects a fhir patient object to be passed in.
Unfortunately we can't just modify the current apis since this returned three types of matches and not only potential matches