### PR TITLE
ISSUE-141: Remove potential matches from the Auto-matches screen

### DIFF
--- a/ui/src/views/Resolve.vue
+++ b/ui/src/views/Resolve.vue
@@ -213,7 +213,7 @@
                 <h5 class="text-uppercase">Scores</h5>
               </v-list-item>
               <v-list-item
-                v-for="(score,source_id) in data.scores"
+                v-for="(score,source_id) in filteredScores(data.scores)"
                 :key="data.source_id+'-'+source_id"
                 >
                 <v-list-item-content>{{getSource(source_id)}}</v-list-item-content>
@@ -318,11 +318,20 @@ export default {
   created: function() {
     this.$store.state.progress.enable = true;
     this.$store.state.progress.width = "300px";
-    this.$store.state.progress.title =  this.$t('loading_potential');
-    if(this.$route.query.flagType === 'autoMatches'){
-      this.$store.state.progress.title =  this.$t('loading_auto');
-    }
+    this.$store.state.progress.title = this.$route.query.flagType === 'autoMatches' ? this.$t('loading_auto') : this.$t('loading_potential');
+
     axios.get(`/ocrux/match/potential-matches/${this.$route.params.clientId}`).then((resp) => {
+
+    let responseData = resp.data;
+    if(this.$route.query.flagType === 'autoMatches'){
+
+      const parentObject = responseData.find(item => item.id === this.$route.params.clientId);
+
+      if (parentObject) {
+        responseData = responseData.filter(item => item.uid === parentObject.uid);
+      }
+      
+    }
         let extRegexPattern = /^extension_/;
 
         let matchingKeys = [];
@@ -363,6 +372,19 @@ export default {
   computed: {
     cridHeader: function() {
       return this.useNickname ?  this.$t('Temporary_cr_id') + ( this.includeCRID ? " / Actual CR ID" : "") : "CR ID"
+    },
+    filteredScores(scores) {
+        return (data) => {
+          const filteredScores = {};
+
+            Object.entries(data)
+              .forEach(([source_id, value]) => {
+                if (this.getSource(source_id) !== null && this.getSource(source_id) !== '') {
+                  filteredScores[source_id] = value;
+                }
+              });
+            return filteredScores;
+        }
     },
     bucketsModified () {
       for(let matrix of this.resolves) {
@@ -416,7 +438,8 @@ export default {
       return this.useNickname ? this.nickname[crid] + ( this.includeCRID ? " ("+crid+")" : "" ): crid
     },
     getSource: function(source_id) {
-      return this.resolves.find( resolve => resolve.source_id === source_id ).source
+      const resolvedObject = this.resolves.find(resolve => resolve.source_id === source_id);
+      return resolvedObject ? resolvedObject.source : '';
     },
     moveClient: function(val,item) {
       this.copyCohortInfo = { old_id: item.uid, new_id: val, item: item }


### PR DESCRIPTION
The auto match screen should only return patients that are auto matches and exclude the potential matches

Currently
<img width="1232" alt="double auto" src="https://github.com/intrahealth/client-registry/assets/47450907/8cd842b1-68e9-4e99-bce6-188640b6f070">
PR changes
<img width="1232" alt="single auto" src="https://github.com/intrahealth/client-registry/assets/47450907/0c649d17-e0a4-46ac-b14e-3f09c79e9ad5">
