### PR TITLE
Fix crash when resource.link is undefined in match processing

### DIFF
--- a/server/lib/mixins/matchMixin.js
+++ b/server/lib/mixins/matchMixin.js
@@ -589,7 +589,7 @@ const addPatient = (clientID, patientsBundle, callback) => {
       let existsAutoMatches = false;
       for(const auto of FHIRAutoMatched.entry) {
         let isCurrentLink = currentLinks.find((currentLink) => {
-          return auto.resource.link.find((link) => {
+          return auto.resource.link && auto.resource.link.find((link) => {
             return link.other.reference === currentLink.resource.resourceType + "/" + currentLink.resource.id;
           });
         });
@@ -623,7 +623,7 @@ const addPatient = (clientID, patientsBundle, callback) => {
       let existsPotentialMatches = false;
       for(const potential of FHIRPotentialMatches.entry) {
         let isCurrentLink = currentLinks.find((currentLink) => {
-          return potential.resource.link.find((link) => {
+          return potential.resource.link && potential.resource.link.find((link) => {
             return link.other.reference === currentLink.resource.resourceType + "/" + currentLink.resource.id;
           });
         });
@@ -682,7 +682,7 @@ const addPatient = (clientID, patientsBundle, callback) => {
       let existsConflictMatches = false;
       for(const conflict of FHIRConflictsMatches.entry) {
         let isCurrentLink = currentLinks.find((currentLink) => {
-          return conflict.resource.link.find((link) => {
+          return conflict.resource.link && conflict.resource.link.find((link) => {
             return link.other.reference === currentLink.resource.resourceType + "/" + currentLink.resource.id;
           });
         });
@@ -745,7 +745,7 @@ const addPatient = (clientID, patientsBundle, callback) => {
         const existLinkPromise = new Promise((resolve) => {
           if (currentLinks.length > 0) {
             for (const entry of currentLinks) {
-              const exist = entry.resource.link.find((link) => {
+              const exist = entry.resource.link && entry.resource.link.find((link) => {
                 return link.other.reference === 'Patient/' + patient.id;
               });
               if (entry.resource.link && entry.resource.link.length === 1 && exist) {


### PR DESCRIPTION
## Problem

The app crashes with `TypeError: Cannot read properties of undefined (reading 'find')` when a Patient resource has no `link` array during match processing.

```
matchMixin.js:748
const exist = entry.resource.link.find((link) => { ...
                               ^
TypeError: Cannot read properties of undefined (reading 'find')
```

This happens because `resource.link` can be `undefined` when a patient is first submitted, has been unlinked, or when the FHIR store returns a resource without links.

## Fix

Add `resource.link &&` guard before `.find()` at four locations in `matchMixin.js`:

| Line | Context | Before | After |
|------|---------|--------|-------|
| 748 | Golden record reuse check | `entry.resource.link.find(...)` | `entry.resource.link && entry.resource.link.find(...)` |
| 592 | Auto match current link check | `auto.resource.link.find(...)` | `auto.resource.link && auto.resource.link.find(...)` |
| 626 | Potential match current link check | `potential.resource.link.find(...)` | `potential.resource.link && potential.resource.link.find(...)` |
| 685 | Conflict match current link check | `conflict.resource.link.find(...)` | `conflict.resource.link && conflict.resource.link.find(...)` |

This matches the pattern already used at line 928 (`currentLink.resource.link && currentLink.resource.link.find(...)`) which was the only guarded call.

The `addLinks` function (lines 515, 530) is safe because lines 512-513 and 527-528 already initialize `link` to `[]` if missing.

Fixes #153