### PR TITLE
Fix incorrect 500 status on bundle POST with only Patients

### DIFF
--- a/server/lib/routes/fhir.js
+++ b/server/lib/routes/fhir.js
@@ -202,7 +202,7 @@ router.post('/', (req, res) => {
   async.parallel({
     otherResources: (callback) => {
       if(otherResources.entry.length === 0) {
-        return callback(null, {});
+        return callback(null, {code: 200});
       }
       fhirWrapper.create(otherResources, (code, err, response, body) => {
         return callback(null, {code, err, response, body});
@@ -210,7 +210,7 @@ router.post('/', (req, res) => {
     },
     patients: (callback) => {
       if(patients.length === 0) {
-        return callback(null, {});
+        return callback(null, {code: 200, responseBundle: {entry: []}, responseHeaders: {}, operationSummary: []});
       }
       let patientsBundle = {
         entry: patients


### PR DESCRIPTION
## Problem

When a FHIR transaction bundle containing only Patient resources is POSTed to `/`, the server returns HTTP 500 instead of 200.

**Root cause** in `fhir.js` line 204:

```js
if(otherResources.entry.length === 0) {
  return callback(null, {});  // returns empty object — no code property
}
```

Then at line 240:
```js
if(results.patients.code > results.otherResources.code) {
  code = results.patients.code;
} else {
  code = results.otherResources.code;  // undefined
}
if(!code) {
  code = 500;  // defaults to 500
}
```

`200 > undefined` is `false` in JavaScript, so `code` gets `undefined`, then defaults to 500.

The symmetric case also has a bug: if the bundle has only non-Patient resources, `results.patients` is `{}`, and line 249 (`results.patients.responseBundle.entry`) crashes with `Cannot read properties of undefined`.

## Fix

Return `{code: 200}` from the empty otherResources callback, and `{code: 200, responseBundle: {entry: []}, responseHeaders: {}, operationSummary: []}` from the empty patients callback.

Fixes #68