### PR TITLE
Handle read-only config file gracefully in Docker Swarm

### DIFF
--- a/server/lib/mixins/generalMixin.js
+++ b/server/lib/mixins/generalMixin.js
@@ -46,13 +46,20 @@ const updateConfigFile = (path, newValue, callback) => {
   config.set(pathString, newValue);
   logger.info('Updating config file');
   const configFile = `${__dirname}/../../config/config_${env}.json`;
-  const configData = require(configFile);
+  let configData;
+  try {
+    configData = require(configFile);
+  } catch (err) {
+    logger.warn('Could not read config file for update, in-memory config is still current: ' + err.message);
+    return callback();
+  }
   setNestedKey(configData, path, newValue, () => {
     fs.writeFile(configFile, JSON.stringify(configData, 0, 2), (err) => {
       if (err) {
-        throw err;
+        logger.warn('Could not write config file (read-only filesystem?), in-memory config is still current: ' + err.message);
+      } else {
+        logger.info('Done updating config file');
       }
-      logger.info('Done updating config file');
       return callback();
     });
   });


### PR DESCRIPTION
## Problem

In Docker Swarm, config files are mounted as read-only Docker configs. When `updateConfigFile()` in `generalMixin.js` tries to write back to the config file (e.g., to update `sync.lastFHIR2ESSync` after an ES re-index), `fs.writeFile` fails and `throw err` on line 53 **crashes the entire process**.

This affects any deployment using Docker Swarm or Kubernetes where config files are immutable.

```
Error: EROFS: read-only file system, open '/src/server/config/config_docker.json'
```

## Fix

- `config.set()` still updates the **in-memory** config (always works, keeps runtime state correct)
- `fs.writeFile` failure now logs a warning instead of crashing
- `require(configFile)` failure is also handled (in case the file is inaccessible)
- The callback is always invoked so the calling code continues normally

The in-memory config remains correct for the duration of the process. On restart, the mounted config file is re-read — so values like `lastFHIR2ESSync` will reset to whatever is in the Docker config, which means the next startup will do a full ES re-sync from that timestamp. This is expected behavior in immutable infrastructure.

Fixes #139