### PR TITLE
Fix ternary operator precedence bug in search filter label

### DIFF
--- a/ui/src/views/Home.vue
+++ b/ui/src/views/Home.vue
@@ -216,7 +216,7 @@ export default {
               if(searchable && searchparameter) {
                 let filter = {
                   searchparameter: searchparameter.valueString,
-                  label: this.$t('search')+ "_" + translatedHeader ? translatedHeader: label.valueString
+                  label: this.$t('search')+ "_" + (translatedHeader ? translatedHeader : label.valueString)
                 }
                 if(valueset && valueset.valueString) {
                   filter.binding = valueset.valueString


### PR DESCRIPTION
## Summary
- Fix JavaScript operator precedence bug in `Home.vue` search filter label construction
- The expression `this.$t("search") + "_" + translatedHeader ? translatedHeader : label.valueString` was binding the ternary `?` to the entire concatenated string, not just `translatedHeader`
- Added parentheses around the ternary: `(translatedHeader ? translatedHeader : label.valueString)`