### PR TITLE
Remove hardcoded UUID and test route from Client.vue

### DIFF
--- a/ui/src/views/Client.vue
+++ b/ui/src/views/Client.vue
@@ -10,9 +10,6 @@
       <v-tab href="#history"><v-icon>mdi-history</v-icon>{{  $t('history') }}</v-tab>
       <v-spacer></v-spacer>
       <v-toolbar-items>
-        <v-btn v-if="uid === '6f2eac1b-5b1d-49ce-a4b7-f9089128f836'" color="warning" @click="$router.push('/resolve/590-57-2820')">
-          <v-badge icon="mdi-alert" color="error" >{{ $t('review_potential_matches') }}</v-badge>
-        </v-btn>
         <v-btn color="secondary" @click="$router.go(-1)" v-if="canGoBack">{{  $t('back') }}</v-btn>
         <v-btn color="secondary" @click="close" v-else>{{  $t('close') }}</v-btn>
       </v-toolbar-items>


### PR DESCRIPTION
## Summary
- Remove a "Review Potential Matches" button in `Client.vue` that was gated behind a hardcoded UUID (`6f2eac1b-5b1d-49ce-a4b7-f9089128f836`) and linked to a hardcoded test route (`/resolve/590-57-2820`)
- This was leftover development/demo code that served no purpose in production since it only activated for one specific CRUID

## Test plan
- [ ] Verify the Client detail page loads without errors after the button removal
- [ ] Verify the back/close navigation buttons still work correctly